### PR TITLE
Change jet color scale to turbo

### DIFF
--- a/vignettes/TCGAWorkflow.Rmd
+++ b/vignettes/TCGAWorkflow.Rmd
@@ -1449,7 +1449,7 @@ ra = rowAnnotation(
 heatmap  <- Heatmap(
   matrix = assay(sig.met),
   name = "DNA methylation",
-  col = matlab::jet.colors(200),
+  col = viridisLite::turbo(200),
   show_row_names = FALSE,
   cluster_rows = TRUE,
   cluster_columns = FALSE,


### PR DESCRIPTION
Firstly this improves some of the shortcomings of the jet scale (see
[here](https://ai.googleblog.com/2019/08/turbo-improved-rainbow-colormap-for.html)). Secondly, this removes the need for the non-free `matlab` package.